### PR TITLE
[Fix]: Main content overlaps the sidebar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -249,6 +249,7 @@ textarea {
   padding-top: 20px;
   left: 240px;
   position: absolute;
+  z-index: -1;
 }
 
 .homePage .post {


### PR DESCRIPTION
**Hey, @AKD-01 overlap issue has been resolved.** 

But there are some issues in responsiveness -> when the screen size is reduced, the sidebar should not be properly responsive.

Can I refactor the codebase / could you assign me issues?

![image](https://github.com/AKD-01/blogweet/assets/77252075/0d00cb2a-da8d-45a9-9870-1443f4bb6d43)
