### PR TITLE
fixing the extra space in the attribute value

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="./twitter-round-icon.svg " />
+    <link rel="icon" href="./twitter-round-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta


### PR DESCRIPTION
There is an extra space at the end of the href attribute value. It should be removed to ensure the correct path is used for the favicon. The corrected line should be: