### PR TITLE
fixed issue where deletion of post did not need confirmation

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -87,7 +87,10 @@ function Home({ isAuth }) {
                     post.author.id === auth.currentUser.uid && (
                       <button
                         onClick={() => {
-                          deletePost(post.id);
+                          const confirmed = window.confirm("Are you sure you want to delete this post?");
+                          if (confirmed) {
+                              deletePost(post.id);
+                            }
                         }}
                       >
                         {" "}


### PR DESCRIPTION
Fixed <a href="https://github.com/AKD-01/blogweet/issues/148">Issue#148</a>. Added a confirmation to be asked before deletion of a post


![issue148](https://github.com/AKD-01/blogweet/assets/88048601/de0c8d57-85ea-4350-9e2a-5d157b109a3d)