### PR TITLE
Adding emailjs feature in contact us page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,12 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "boxicons": "^2.1.4",
+        "emailjs-com": "^3.2.0",
         "firebase": "^9.15.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.6.1",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "react-toastify": "^9.1.1",
         "web-vitals": "^2.1.4"
       }
@@ -7540,6 +7541,15 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+    },
+    "node_modules/emailjs-com": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
+      "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA==",
+      "deprecated": "The SDK name changed to @emailjs/browser",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -23531,6 +23541,11 @@
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+    },
+    "emailjs-com": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/emailjs-com/-/emailjs-com-3.2.0.tgz",
+      "integrity": "sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA=="
     },
     "emittery": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "boxicons": "^2.1.4",
+    "emailjs-com": "^3.2.0",
     "firebase": "^9.15.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.6.1",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "react-toastify": "^9.1.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/pages/Contact.js
+++ b/src/pages/Contact.js
@@ -1,6 +1,25 @@
 import React from "react";
-import "./Contact.css"
+import "./Contact.css";
+import {useRef} from "react";
+import emailjs from 'emailjs-com';
+
 const Contact=()=>{
+
+    const form = useRef();
+
+    const sendEmail = (e) => {
+      e.preventDefault();
+
+
+    //  YOUR_SERVICE_ID = service_fe7xt7q 
+    //  YOUR_TEMPLATE_ID = template_twttpr5
+    //  YOUR_PUBLIC_KEY = -hZabQ8Vke9nL6Qvs
+  
+      emailjs.sendForm('service_fe7xt7q', 'template_twttpr5', form.current, '-hZabQ8Vke9nL6Qvs')
+        e.target.reset()
+    };
+  
+
     return (
         <div className="Contactus">
             <h1>Contact Us</h1>
@@ -8,7 +27,7 @@ const Contact=()=>{
             <p>
             Please fill out the form below to get in touch with us:
              </p>
-            <form>
+            <form ref={form} onSubmit={sendEmail}>
                 <div >
                 <label htmlFor="name">Name:</label>
                 <input type="text" id="name"></input>
@@ -21,7 +40,7 @@ const Contact=()=>{
                 <label htmlFor="message">Message:</label>
                 <textarea id="message" rows="6"></textarea>
                 </div>
-                <button>Submit</button>
+                <button type='submit'>Submit</button>
             </form>
         </div>
     );


### PR DESCRIPTION
[REQUEST] - Responsive Contact Us page


Closes: #271


## Description of Changes
I have added EmailJs to the Contact Us page through my email id till now and it is running completely perfectly. You just have to replace your email in place of mine.

Just follow these simple  steps:
1) Sign up on the official website of EmailJs: https://www.emailjs.com/
2) Just Create a service from the email service.
3) Replace (YOUR_SERVICE_ID, YOUR_TEMPLATE_ID, YOUR_PUBLIC_KEY) in the contact.js page from the official website of emailjs.

## Screenshots

In this Screenshot, you can see I received this message directly from the Blogweet website.

![Screenshot 2023-05-31 181341](https://github.com/AKD-01/blogweet/assets/97357814/84975d98-d8d3-44a8-894c-996d40c223d0)

For adding Email Service just click add new service please refer to this image,

![Screenshot 2023-05-31 181409](https://github.com/AKD-01/blogweet/assets/97357814/0bfeaf6e-3f5d-4a6d-9bd1-671cdb922603)

For adding Template Service just click add new service please refer to this image,

![Screenshot 2023-05-31 181426](https://github.com/AKD-01/blogweet/assets/97357814/9bc1044d-0858-412b-a1cc-07214e9cbaa9)



